### PR TITLE
Use the same localization for Double inputs as is used in formatting output.

### DIFF
--- a/src/com/mrcrayfish/modelcreator/util/Parser.java
+++ b/src/com/mrcrayfish/modelcreator/util/Parser.java
@@ -1,15 +1,19 @@
 package com.mrcrayfish.modelcreator.util;
 
+import java.text.DecimalFormat;
+import java.text.ParseException;
+
 public class Parser
 {
+	private static DecimalFormat df = new DecimalFormat("#.#");
 	public static double parseDouble(String text, double def)
 	{
 		double value;
 		try
 		{
-			value = Double.parseDouble(text);
+			value = df.parse(text).doubleValue();
 		}
-		catch (NumberFormatException e)
+		catch (ParseException e)
 		{
 			value = def;
 		}


### PR DESCRIPTION
This caused a weird ux experience where changing a number after the decimal seperator wasn't accepted as a valid change.